### PR TITLE
display zero values correctly for totaltime and bladetime

### DIFF
--- a/packages/landroid.yaml
+++ b/packages/landroid.yaml
@@ -131,6 +131,8 @@ sensor:
             {% set t = state_attr('sensor.landroid_mower_status', 'blade_time') | int %}
             {% if t != 0 %}
               {{ '%0d d %0.02d h %0.02d min' | format(t // 1440, ((t % 1440) // 60), t % 60) }}
+            {%- else -%}
+               {{ '0 min' }}
             {% endif %}
         icon_template: mdi:fan
         unit_of_measurement: "min"
@@ -143,6 +145,8 @@ sensor:
             {% set t = state_attr('sensor.landroid_mower_status', 'work_time') | int %}
             {% if t != 0 %}
               {{ '%0d d %0.02d h %0.02d min' | format(t // 1440, ((t % 1440) // 60), t % 60) }}
+            {%- else -%}
+               {{ '0 min' }}
             {% endif %}
         icon_template: mdi:bus-clock
         unit_of_measurement: "min"


### PR DESCRIPTION
For a brand new landroid the totaltime and bladetime values are zero and therefore not displayed correctly.